### PR TITLE
Add hook to enable drag functionality, add example

### DIFF
--- a/example/src/App.jsx
+++ b/example/src/App.jsx
@@ -3,6 +3,7 @@ import { SnapList, SnapItem, useScroll } from 'react-snaplist-carousel';
 import { Frame } from './Frame';
 import { NavBar } from './NavBar';
 import { Menu } from './Menu';
+import { HorizontalDraggable } from './HorizontalDraggable';
 import { Horizontal } from './Horizontal';
 import { Vertical } from './Vertical';
 import { List } from './List';
@@ -45,6 +46,9 @@ export const App = () => {
         </SnapItem>
         <SnapItem snapAlign="start" width="100%">
           <List />
+        </SnapItem>
+        <SnapItem snapAlign="start" width="100%">
+          <HorizontalDraggable />
         </SnapItem>
       </SnapList>
     </Frame>

--- a/example/src/HorizontalDraggable/HorizontalDraggable.jsx
+++ b/example/src/HorizontalDraggable/HorizontalDraggable.jsx
@@ -1,0 +1,57 @@
+import React, { useRef } from 'react';
+
+import { SnapList, SnapItem, useVisibleElements, useScroll, useDrag } from 'react-snaplist-carousel';
+
+import styles from './styles.module.css';
+
+const Item = ({ onClick, children, visible }) => (
+  <div
+    className={styles.item}
+    style={{
+      background: visible ? '#bce6fe' : '#cccccc',
+      cursor: visible ? 'default' : 'pointer',
+    }}
+    onClick={onClick}
+  >
+    {children}
+  </div>
+);
+
+export const HorizontalDraggable = () => {
+  const snapList = useRef(null);
+
+  const visible = useVisibleElements({ debounce: 10, ref: snapList }, ([element]) => element);
+  const goTo = useScroll({ ref: snapList });
+
+  useDrag(snapList);
+
+  return (
+    <SnapList ref={snapList} direction="horizontal">
+      <SnapItem padding={{ left: '15px', right: '15px' }} width="60%" snapAlign="center">
+        <Item onClick={() => goTo(0)} visible={visible === 0}>
+          Item 0
+        </Item>
+      </SnapItem>
+      <SnapItem padding={{ left: '15px', right: '15px' }} width="60%" snapAlign="center">
+        <Item onClick={() => goTo(1)} visible={visible === 1}>
+          Item 1
+        </Item>
+      </SnapItem>
+      <SnapItem padding={{ left: '15px', right: '15px' }} width="60%" snapAlign="center">
+        <Item onClick={() => goTo(2)} visible={visible === 2}>
+          Item 2
+        </Item>
+      </SnapItem>
+      <SnapItem padding={{ left: '15px', right: '15px' }} width="60%" snapAlign="center">
+        <Item onClick={() => goTo(3)} visible={visible === 3}>
+          Item 3
+        </Item>
+      </SnapItem>
+      <SnapItem padding={{ left: '15px', right: '15px' }} width="60%" snapAlign="center">
+        <Item onClick={() => goTo(4)} visible={visible === 4}>
+          Item 4
+        </Item>
+      </SnapItem>
+    </SnapList>
+  );
+};

--- a/example/src/HorizontalDraggable/index.js
+++ b/example/src/HorizontalDraggable/index.js
@@ -1,0 +1,1 @@
+export * from './HorizontalDraggable';

--- a/example/src/HorizontalDraggable/styles.module.css
+++ b/example/src/HorizontalDraggable/styles.module.css
@@ -1,0 +1,7 @@
+.item {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/example/src/Menu/Menu.jsx
+++ b/example/src/Menu/Menu.jsx
@@ -47,6 +47,10 @@ export const Menu = ({ onSelect }) => {
           <img src={list} alt="list-example" width="100%" onClick={() => onSelect(3)}/>
           <div className={styles.exampleTitle}>List</div>
         </div>
+        <div className={styles.example}>
+          <img src={horizontal} alt="horizontal-draggable-example" width="100%" onClick={() => onSelect(4)}/>
+          <div className={styles.exampleTitle}>Horizontal (draggable)</div>
+        </div>
       </div>
     </div>
   );

--- a/example/src/Menu/styles.module.css
+++ b/example/src/Menu/styles.module.css
@@ -44,7 +44,7 @@ margin-bottom: 5px;
 
 .examples {
   display: grid;
-  grid-template-columns: 25% 25% 25%;
+  grid-template-columns: 20% 20% 20% 20%;
   grid-column-gap: 30px;
   padding: 15px 20px 0;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { SnapItem, SnapList } from './SnapList';
+export { useDrag } from './useDrag';
 export { useScroll } from './useScroll';
 export { useVisibleElements } from './useVisibleElements';

--- a/src/stylesdrag.css
+++ b/src/stylesdrag.css
@@ -1,0 +1,15 @@
+.snaplist_smoothscroll {
+  scroll-behavior: smooth;
+}
+
+.snaplist_nosmoothscroll {
+  scroll-behavior: auto;
+}
+
+.snaplist_drag {
+  scroll-snap-type: none;
+}
+
+.snaplist_drag * {
+  user-select: none;
+}

--- a/src/stylesdrag.css
+++ b/src/stylesdrag.css
@@ -1,11 +1,3 @@
-.snaplist_smoothscroll {
-  scroll-behavior: smooth;
-}
-
-.snaplist_nosmoothscroll {
-  scroll-behavior: auto;
-}
-
 .snaplist_drag {
   scroll-snap-type: none;
 }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -15,3 +15,7 @@ declare module '*.svg' {
   export default svgUrl;
   export { svgComponent as ReactComponent };
 }
+
+interface Window {
+  DocumentTouch: any;
+}

--- a/src/useDrag.ts
+++ b/src/useDrag.ts
@@ -3,9 +3,11 @@ import { useEffect } from 'react';
 
 import styles from './stylesdrag.css';
 import { useScroll } from './useScroll';
+import { isTouchDevice } from './utils';
 
 // as found on stackoverflow: https://stackoverflow.com/a/19277804
 const getClosest = (l: number[], t: number): number => l.reduce((p, c) => (Math.abs(c - t) < Math.abs(p - t) ? c : p));
+
 const getElementPosition = (parent: HTMLElement, element: HTMLElement): number =>
   element.offsetLeft - (parent.offsetWidth / 2 - element.offsetWidth / 2) - parent.offsetLeft;
 
@@ -99,7 +101,8 @@ export const useDrag = (ref: RefObject<any>) => {
   }, [ref, handleClick, handleMouseDown, handleMouseMove, handleMouseUp]);
 
   useEffect(() => {
-    if (!ref.current) return;
+    // skip on touch devices
+    if (!ref.current || isTouchDevice()) return;
 
     const target = ref.current;
     const children = target.children;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,3 +31,10 @@ export const mapItem = ({
 
   return { left, width, right, top, height, bottom, paddingLeft, paddingRight, paddingTop, paddingBottom, snapAlign };
 };
+
+export const isTouchDevice = () =>
+  !!(
+    typeof window !== 'undefined' &&
+    ('ontouchstart' in window ||
+      (window.DocumentTouch && typeof document !== 'undefined' && document instanceof window.DocumentTouch))
+  ) || !!(typeof navigator !== 'undefined' && (navigator.maxTouchPoints || navigator.msMaxTouchPoints));


### PR DESCRIPTION
Hi Luis, this PR adds a `useDrag` hook, that enables dragging functionality on non-touch devices.

It uses CSS classes to disable the snap points while dragging. Also there’s a hacky part, where the hook listens to `onScroll` events to clear and fire timeouts. When scrolling ends, the timeout isn’t cleared, thus fires and re-enables the snap points.

This part could probably be simplified by using your `scrollTo` (polyfill) functions, but I only saw those after implementing this hook.

Let me know what you think!