### PR TITLE
Fix for cannot read property 'split' of undefined

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@ export const mapStyles = ($item: HTMLElement) => {
   const paddingRight = parseInt(styles.paddingRight || '');
   const paddingTop = parseInt(styles.paddingTop || '');
   const paddingBottom = parseInt(styles.paddingBottom || '');
-  const [snapAlign] = styles.scrollSnapAlign.split(' ');
+  const [snapAlign] = (typeof styles.scrollSnapAlign === 'string' && styles.scrollSnapAlign.split(' ')) || [];
   const scrollPaddingLeft = parseInt(styles.scrollPaddingLeft || '');
   const scrollPaddingRight = parseInt(styles.scrollPaddingRight || '');
   const scrollPaddingTop = parseInt(styles.scrollPaddingTop || '');


### PR DESCRIPTION
This issue was reported by Sentry. I suspect that it was primarily caused by browsers that don't support scrollSnapAlign and so `styles.scrollSnapAlign` wasn't a string. Since implementing this change locally a week ago, we haven't seen this issue reappear.

<img width="924" alt="image" src="https://user-images.githubusercontent.com/5335/81691485-e2a19900-942a-11ea-96c1-205e20a9ee8f.png">
