### PR TITLE
Fix decimal calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,11 @@ This an internal util function used by `useDragToScroll` that can be useful for 
 
 ## Changelog
 
+### Version 4
+
+- Fix decimal pixel problems
+- **Breakchange** useDragToScroll is returning `{ isDragging }` instead of the boolean. https://github.com/luispuig/react-snaplist-carousel/commit/a2d23d6b804dcab1da9520db8edc746c6837f23e#diff-e3457effa5fa347d185fdd0d08ba3209R173
+
 ### Version 3
 
 - Added useDragToScroll

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-snaplist-carousel",
-  "version": "3.2.2",
+  "version": "4.0.0",
   "description": "A light, pure React, no dependencies and flexible carousel. A modern way to do a classic thing.",
   "author": "luispuig",
   "license": "MIT",

--- a/src/useVisibleElements.ts
+++ b/src/useVisibleElements.ts
@@ -32,8 +32,8 @@ export const getVisibleChildren = ($viewport?: HTMLDivElement | null) => {
   for (let index = 0; index < $items.length; index++) {
     const $item = $items[index] as HTMLElement;
     const item = mapItem({ $item, viewport });
-    const isVisibleHorizontally = item.left >= viewport.left && item.right <= viewport.right;
-    const isVisibleVertically = item.top >= viewport.top && item.bottom <= viewport.bottom;
+    const isVisibleHorizontally = item.left >= Math.floor(viewport.left) && item.right <= Math.ceil(viewport.right);
+    const isVisibleVertically = item.top >= Math.floor(viewport.top) && item.bottom <= Math.ceil(viewport.bottom);
     const isInCenterHorizontally = item.left <= viewport.centerHorizontal && item.right >= viewport.centerHorizontal;
     const isInCenterVertically = item.top <= viewport.centerVertical && item.bottom >= viewport.centerVertical;
     if (isVisibleHorizontally && isVisibleVertically) {


### PR DESCRIPTION
This PR fixes the issue viewport left / right is miscalculated on Android Chrome https://github.com/luispuig/react-snaplist-carousel/issues/27

It also bumps the version to 4 because of the breaking change notified at https://github.com/luispuig/react-snaplist-carousel/issues/23