### PR TITLE
Fix focus event

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,8 +399,7 @@ This an internal util function used by `useDragToScroll` that can be useful for 
 - Version `4.2.0`. Add useScroll / goTo / animationEnabled option. Usefull to scroll on component mount.
 - Version `4.3.0`.
   - Removed `event.preventDefault()` form `mouseDown` so focus event can be propagated up in the DOM tree.
-  - `<SnapList>` and `<SnapItem>` now accept all the `HTMLDivElement` properties.
-  - `<SnapItem>` now accepts a `ref` property.
+  - `<SnapList>` now accept all the `HTMLDivElement` properties.
   - New className attached so it is easier to target it through CSS:
     - `<SnapList>` has a `.snaplist`.
     - `<SnapItem>` has a `.snapitem`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,63 @@ export const App = () => (
 );
 ```
 
+## A11y Example
+
+```tsx
+import * as React from 'react';
+
+import { SnapList, SnapItem } from 'react-snaplist-carousel';
+
+const MyItem = ({ children }) => (
+  <div style={{ width: '70vw', height: 200, background: '#cccccc' }}>
+    {children}
+  </div>
+);
+
+export const App = () => {
+  const snapList = useRef(null);
+  const lastSnapItem = useRef(null);
+  const goToSnapItem = useScroll({ ref: snapList });
+  return (
+    <SnapList
+      ref={snapList}
+      tabIndex={0} // so it can receive focus and can be scrolled with keyboard
+      role="region" // context for screen readers
+      aria-label="my awesome snaplist" // for screen readers to read out loud on focus
+    >
+      <SnapItem margin={{ left: '15px', right: '15px' }} snapAlign="center">
+        <MyItem>Item 0</MyItem>
+        <button
+          onClick={() => {
+            goToSnapItem(4);
+            lastSnapItem.current?.focus();
+          }}
+        >
+          go to last item
+        </button>
+      </SnapItem>
+      <SnapItem margin={{ left: '15px', right: '15px' }} snapAlign="center">
+        <MyItem>Item 1</MyItem>
+      </SnapItem>
+      <SnapItem margin={{ left: '15px', right: '15px' }} snapAlign="center">
+        <MyItem>Item 2</MyItem>
+      </SnapItem>
+      <SnapItem margin={{ left: '15px', right: '15px' }} snapAlign="center">
+        <MyItem>Item 3</MyItem>
+      </SnapItem>
+      <SnapItem
+        margin={{ left: '15px', right: '15px' }}
+        snapAlign="center"
+        ref={lastSnapItem}
+        tabIndex={-1}
+      >
+        <MyItem>Item 4</MyItem>
+      </SnapItem>
+    </SnapList>
+  );
+};
+```
+
 ## Advanced Example
 
 ```tsx
@@ -176,6 +233,7 @@ export const App = () => {
   bottom?: string;
   left?: string;
   } | undefined }: The margin is used to set the separation between the items. You can use different margin for the first and last item to get better results.
+- `ref` { React.RefObject\<HTMLDivElement\> | undefined }. You can use it to programatically focus the `SnapItem` for example.
 - `className` { string | undefined }: 🚑Please, use this only in case of emergency. It allows you to add/overwrite/extend all the CSS properties. If you need this, please consider opening an issue or contribute with a PR to cover your use case.
 
 \* _Required fields_
@@ -339,6 +397,13 @@ This an internal util function used by `useDragToScroll` that can be useful for 
 - **Breakchange** useDragToScroll is returning `{ isDragging }` instead of the boolean. https://github.com/luispuig/react-snaplist-carousel/commit/a2d23d6b804dcab1da9520db8edc746c6837f23e#diff-e3457effa5fa347d185fdd0d08ba3209R173
 - Version `4.1.0`. Fix support for macOS Big Sur
 - Version `4.2.0`. Add useScroll / goTo / animationEnabled option. Usefull to scroll on component mount.
+- Version `4.3.0`.
+  - Removed `event.preventDefault()` form `mouseDown` so focus event can be propagated up in the DOM tree.
+  - `<SnapList>` and `<SnapItem>` now accept all the `HTMLDivElement` properties.
+  - `<SnapItem>` now accepts a `ref` property.
+  - New className attached so it is easier to target it through CSS:
+    - `<SnapList>` has a `.snaplist`.
+    - `<SnapItem>` has a `.snapitem`.
 
 ### Version 3
 

--- a/example/src/A11y/A11y.jsx
+++ b/example/src/A11y/A11y.jsx
@@ -1,0 +1,156 @@
+import React, { useRef } from 'react';
+
+import { SnapList, SnapItem, useVisibleElements, useScroll, useDragToScroll } from 'react-snaplist-carousel';
+
+import styles from './styles.module.css';
+
+const Item = ({ onClick, children, visible, ...props }) => (
+  <div
+    className={styles.item}
+    style={{
+      background: visible ? '#bce6fe' : '#cccccc',
+      cursor: visible ? 'default' : 'pointer',
+    }}
+    onClick={onClick}
+    {...props}
+  >
+    {children}
+  </div>
+);
+
+const itemWidth = 100;
+
+const List = ({ id }) => {
+  const snapList = useRef(null);
+  const snapItem14 = useRef(null);
+
+  const visible = useVisibleElements({ debounce: 10, ref: snapList }, (elements, elementInCenter) => elementInCenter);
+  const goToChildren = useScroll({ ref: snapList });
+  useDragToScroll({ ref: snapList });
+
+  return (
+    <div className={styles.wrapper} id="list">
+      <SnapList
+        ref={snapList}
+        direction="horizontal"
+        height="auto"
+        tabIndex={0}
+        role="region"
+        aria-label={`my list number ${id}`}
+      >
+        <SnapItem margin={{ left: `calc(50% - (${itemWidth}px/2)`, right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(0)} visible={visible === 0} tabIndex={0}>
+            Item 0<br />
+            <button
+              onClick={() => {
+                goToChildren(14);
+                snapItem14.current && snapItem14.current.focus();
+              }}
+            >
+              go to last
+            </button>
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(1)} visible={visible === 1}>
+            Item 1
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(2)} visible={visible === 2}>
+            Item 2
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(3)} visible={visible === 3}>
+            Item 3
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(4)} visible={visible === 4}>
+            Item 4
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(5)} visible={visible === 5}>
+            Item 5
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(6)} visible={visible === 6}>
+            Item 6
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(7)} visible={visible === 7}>
+            Item 7
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(8)} visible={visible === 8}>
+            Item 8
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(9)} visible={visible === 9}>
+            Item 9
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(10)} visible={visible === 10}>
+            Item 10
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(11)} visible={visible === 11}>
+            Item 11
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(12)} visible={visible === 12}>
+            Item 12
+          </Item>
+        </SnapItem>
+        <SnapItem margin={{ left: '10px', right: '10px' }} snapAlign="center">
+          <Item onClick={() => goToChildren(13)} visible={visible === 13}>
+            Item 13
+          </Item>
+        </SnapItem>
+        <SnapItem
+          ref={snapItem14}
+          tabIndex={-1}
+          margin={{ left: '10px', right: `calc(50% - (${itemWidth}px/2)` }}
+          snapAlign="center"
+        >
+          <Item onClick={() => goToChildren(14)} visible={visible === 14}>
+            Item 14
+          </Item>
+        </SnapItem>
+      </SnapList>
+    </div>
+  );
+};
+
+export const A11y = () => {
+  return (
+    <div className={styles.listsWrapper}>
+      <List id={1} />
+      <List id={2} />
+      <p className={styles.instructions}>
+        <ul className={styles.instructionsList}>
+          <li>Each top level SnapItem element is focusable.</li>
+          <li>Item 0 is also focusable.</li>
+          <li>When clicking the "go to last" button, carousel goes to last item and automatically focuses it.</li>
+          <li>
+            Last item is focusable via script and mouse click, but no keyboard reachable as it has no interactive
+            elements.
+          </li>
+          <li>
+            When a list has focus (either SnapList parent or any child), it can be scrolled through keybaord arrow
+            keys).
+          </li>
+        </ul>
+      </p>
+    </div>
+  );
+};

--- a/example/src/A11y/index.js
+++ b/example/src/A11y/index.js
@@ -1,0 +1,1 @@
+export * from './A11y';

--- a/example/src/A11y/styles.module.css
+++ b/example/src/A11y/styles.module.css
@@ -1,0 +1,34 @@
+.listsWrapper {
+  width: 100%;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.wrapper {
+  width: 100%;
+  max-width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding-bottom: 10%;
+}
+
+.item {
+  width: 100px;
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.instructions {
+  margin-top: 0;
+  padding: 1rem;
+  padding-top: 0;
+}
+
+.instructionsList {
+  margin-top: 0;
+}

--- a/example/src/App.jsx
+++ b/example/src/App.jsx
@@ -6,6 +6,7 @@ import { Menu } from './Menu';
 import { Horizontal } from './Horizontal';
 import { Vertical } from './Vertical';
 import { List } from './List';
+import { A11y } from './A11y';
 
 export const App = () => {
   const snaplist = useRef(null);
@@ -32,7 +33,7 @@ export const App = () => {
 
   return (
     <Frame>
-      <NavBar show={selected > 0} selected={selected} onSelect={select} screens={3} />
+      <NavBar show={selected > 0} selected={selected} onSelect={select} screens={4} />
       <SnapList direction="horizontal" ref={snaplist} disableScroll height="100%">
         <SnapItem snapAlign="start" width="100%">
           <Menu onSelect={select} />
@@ -45,6 +46,9 @@ export const App = () => {
         </SnapItem>
         <SnapItem snapAlign="start" width="100%">
           <List />
+        </SnapItem>
+        <SnapItem snapAlign="start" width="100%">
+          <A11y />
         </SnapItem>
       </SnapList>
     </Frame>

--- a/example/src/Menu/Menu.jsx
+++ b/example/src/Menu/Menu.jsx
@@ -36,16 +36,72 @@ export const Menu = ({ onSelect }) => {
       <b>Examples</b>
       <div className={styles.examples}>
         <div className={styles.example}>
-          <img src={horizontal} alt="horizontal-example" width="100%" onClick={() => onSelect(1)} />
+          <img
+            src={horizontal}
+            alt="horizontal-example"
+            width="100%"
+            onClick={() => onSelect(1)}
+            tabIndex={0}
+            role="button"
+            onKeyDown={e => {
+              if (['Enter', ' '].includes(e.key)) {
+                e.preventDefault();
+                onSelect(1);
+              }
+            }}
+          />
           <div className={styles.exampleTitle}>Horizontal</div>
         </div>
         <div className={styles.example}>
-          <img src={vertical} alt="vertical-example" width="100%" onClick={() => onSelect(2)} />
+          <img
+            src={vertical}
+            alt="vertical-example"
+            width="100%"
+            onClick={() => onSelect(2)}
+            tabIndex={0}
+            role="button"
+            onKeyDown={e => {
+              if (['Enter', ' '].includes(e.key)) {
+                e.preventDefault();
+                onSelect(2);
+              }
+            }}
+          />
           <div className={styles.exampleTitle}>Vertical</div>
         </div>
         <div className={styles.example}>
-          <img src={list} alt="list-example" width="100%" onClick={() => onSelect(3)} />
+          <img
+            src={list}
+            alt="list-example"
+            width="100%"
+            onClick={() => onSelect(3)}
+            tabIndex={0}
+            role="button"
+            onKeyDown={e => {
+              if (['Enter', ' '].includes(e.key)) {
+                e.preventDefault();
+                onSelect(3);
+              }
+            }}
+          />
           <div className={styles.exampleTitle}>List</div>
+        </div>
+        <div className={styles.example}>
+          <img
+            src={list}
+            alt="accessibility-example"
+            width="100%"
+            onClick={() => onSelect(4)}
+            tabIndex={0}
+            role="button"
+            onKeyDown={e => {
+              if (['Enter', ' '].includes(e.key)) {
+                e.preventDefault();
+                onSelect(4);
+              }
+            }}
+          />
+          <div className={styles.exampleTitle}>A11y</div>
         </div>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-snaplist-carousel",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "A light, pure React, no dependencies and flexible carousel. A modern way to do a classic thing.",
   "author": "luispuig",
   "license": "MIT",

--- a/src/SnapList.tsx
+++ b/src/SnapList.tsx
@@ -63,7 +63,7 @@ type WithChildren<T> = T & { children?: React.ReactNode };
 
 export const SnapList = React.forwardRef<HTMLDivElement, WithChildren<CarouselProps>>(SnapListComponent);
 
-interface SnapItemProps extends React.HTMLAttributes<HTMLDivElement> {
+export const SnapItem: React.FC<{
   margin?: {
     top?: string;
     right?: string;
@@ -75,12 +75,7 @@ interface SnapItemProps extends React.HTMLAttributes<HTMLDivElement> {
   snapAlign: 'start' | 'center' | 'end' | 'none';
   forceStop?: boolean;
   className?: string;
-}
-
-const SnapItemComponent: React.FC<SnapItemProps> = (
-  { children, margin, snapAlign = 'center', forceStop = false, width, height, className, ...props },
-  ref: React.Ref<HTMLDivElement>,
-) => (
+}> = ({ children, margin, snapAlign = 'center', forceStop = false, width, height, className }) => (
   <div
     className={mergeStyles(
       'snapitem',
@@ -97,11 +92,7 @@ const SnapItemComponent: React.FC<SnapItemProps> = (
       width,
       height,
     }}
-    ref={ref}
-    {...props}
   >
     {children}
   </div>
 );
-
-export const SnapItem = React.forwardRef<HTMLDivElement, WithChildren<SnapItemProps>>(SnapItemComponent);

--- a/src/SnapList.tsx
+++ b/src/SnapList.tsx
@@ -3,7 +3,7 @@ import { mergeStyles } from './utils';
 
 import styles from './styles.css';
 
-interface CarouselProps {
+interface CarouselProps extends React.HTMLAttributes<HTMLDivElement> {
   direction: 'horizontal' | 'vertical';
   disableScroll?: boolean;
   width?: string;
@@ -30,11 +30,13 @@ const SnapListComponent: React.FC<CarouselProps> = (
     hideScrollbar = true,
     disabled = false,
     className,
+    ...props
   },
   ref: React.Ref<HTMLDivElement>,
 ) => (
   <div
     className={mergeStyles(
+      'snaplist',
       styles.snaplist,
       styles[`snaplist_${direction}`],
       disabled ? null : styles[`snaplist_active_${direction}`],
@@ -51,6 +53,7 @@ const SnapListComponent: React.FC<CarouselProps> = (
       scrollPaddingLeft: scrollPadding?.left ?? '0px',
     }}
     ref={ref}
+    {...props}
   >
     {children}
   </div>
@@ -60,7 +63,7 @@ type WithChildren<T> = T & { children?: React.ReactNode };
 
 export const SnapList = React.forwardRef<HTMLDivElement, WithChildren<CarouselProps>>(SnapListComponent);
 
-export const SnapItem: React.FC<{
+interface SnapItemProps extends React.HTMLAttributes<HTMLDivElement> {
   margin?: {
     top?: string;
     right?: string;
@@ -72,9 +75,15 @@ export const SnapItem: React.FC<{
   snapAlign: 'start' | 'center' | 'end' | 'none';
   forceStop?: boolean;
   className?: string;
-}> = ({ children, margin, snapAlign = 'center', forceStop = false, width, height, className }) => (
+}
+
+const SnapItemComponent: React.FC<SnapItemProps> = (
+  { children, margin, snapAlign = 'center', forceStop = false, width, height, className, ...props },
+  ref: React.Ref<HTMLDivElement>,
+) => (
   <div
     className={mergeStyles(
+      'snapitem',
       styles.snapitem,
       styles[`snapitem_align_${snapAlign}`],
       forceStop ? styles.snapitem_forcestop : null,
@@ -88,7 +97,11 @@ export const SnapItem: React.FC<{
       width,
       height,
     }}
+    ref={ref}
+    {...props}
   >
     {children}
   </div>
 );
+
+export const SnapItem = React.forwardRef<HTMLDivElement, WithChildren<SnapItemProps>>(SnapItemComponent);

--- a/src/useDragToScroll.ts
+++ b/src/useDragToScroll.ts
@@ -72,7 +72,6 @@ export const useDragToScroll = ({ ref, disabled = false }: { ref: RefObject<HTML
   const handleMouseDown = useCallback(
     event => {
       if (!ref.current) return;
-      event.preventDefault();
       isDown.current = true;
       startX.current = event.pageX - ref.current.offsetLeft;
       slideX.current = ref.current.scrollLeft;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,8 @@ interface Styles extends CSSStyleDeclaration {
   scrollPaddingTop?: string;
   scrollPaddingBottom?: string;
 }
-const extractStyleProperty = (property: keyof Styles, styles: Styles): string => styles[property] || '';
+const extractStyleProperty = (property: keyof Styles, styles: Styles): string =>
+  styles[property] === undefined ? '' : String(styles[property]);
 
 export const mapStyles = ($item: HTMLElement) => {
   const styles = window.getComputedStyle($item) as Styles;


### PR DESCRIPTION
SnapList reverted to default. A11y example updated to handle keyboard Enter and space events. Also updated ref management on children.