### PR TITLE
fix: rtl list fix

### DIFF
--- a/src/useDragToScroll.ts
+++ b/src/useDragToScroll.ts
@@ -122,7 +122,7 @@ export const useDragToScroll = ({ ref, disabled = false }: { ref: RefObject<HTML
     const scrollTargetY = getClosest(elementPositionsY.current, dragEndPositionY);
 
     const target =
-      scrollTargetX > 0
+      scrollTargetX !== 0
         ? elementPositionsX.current.indexOf(scrollTargetX)
         : elementPositionsY.current.indexOf(scrollTargetY);
     goToChildren(target);

--- a/src/useScroll.ts
+++ b/src/useScroll.ts
@@ -12,8 +12,9 @@ const toArray = ($items: HTMLCollection) => {
   return children;
 };
 
-const normalize = (value: number, { min, max }: { min: number; max: number }) => {
-  return Math.min(max, Math.max(min, value));
+const normalize = (value: number, { min, max }: { min: number; max: number }, direction?: string) => {
+  var value_ = direction === 'rtl'? Math.min(min, value) : Math.max(min, value);
+  return Math.min(max, value_);
 };
 export const useScroll = ({ ref }: { ref: RefObject<any> }) => {
   const getScrollFor = useCallback(
@@ -80,7 +81,7 @@ export const useScroll = ({ ref }: { ref: RefObject<any> }) => {
       const maxLeftScroll = viewport.scrollWidth - viewport.width;
       const maxTopScroll = viewport.scrollHeight - viewport.height;
       return {
-        left: normalize(target.left, { min: 0, max: maxLeftScroll }),
+        left: normalize(target.left, { min: 0, max: maxLeftScroll }, viewportStyles.direction),
         top: normalize(target.top, { min: 0, max: maxTopScroll }),
       };
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,6 +22,7 @@ export const mapStyles = ($item: HTMLElement) => {
     scrollPaddingRight: parseInt(extractStyleProperty('scrollPaddingRight', styles)),
     scrollPaddingTop: parseInt(extractStyleProperty('scrollPaddingTop', styles)),
     scrollPaddingBottom: parseInt(extractStyleProperty('scrollPaddingBottom', styles)),
+    direction: styles.direction,
   };
 };
 


### PR DESCRIPTION
When page has direction `rtl` (right-to-left) elements has negtive numbers.

This fix take it into consideration in `useScroll` hook and `handleMouseUp` method.